### PR TITLE
#159423801 add data persistence to REST endpoint POST /entries

### DIFF
--- a/server/controllers/entries.js
+++ b/server/controllers/entries.js
@@ -1,76 +1,71 @@
 import Diary from '../models/Diary';
+import { sendResponse } from '../helpers/utils';
 
-export async function postEntry(request, result) {
-  const requiredFields = ['title', 'body', 'author'];
+export async function postEntry(request, response) {
   try {
-    const { title, body, author } = request.body;
+    const { title, body } = request.body;
+    const author = request.user;
     const newDiary = new Diary({ title, body, author });
-    const diary = await Diary.save(newDiary);
-    result.json({
-      data: diary,
-      error: null,
-    });
+    const diary = await newDiary.save();
+    sendResponse({ response, data: diary, status: 201 });
   } catch (error) {
-    result.status(400).json({
-      data: {},
-      error: error.message,
-    });
+    sendResponse({ response, error: [error.message], status: 400 });
   }
 }
-export async function getEntries(request, result) {
+export async function getEntries(request, response) {
   try {
     const entries = await Diary.find();
-    result.json({
+    response.json({
       data: entries,
       error: null,
     });
   } catch (error) {
-    result.status(404).json({
+    response.status(404).json({
       data: {},
       error: error.message,
     });
   }
 }
-export async function getEntry(request, result) {
+export async function getEntry(request, response) {
   try {
     const { id } = request.params;
     const entry = await Diary.findById(id);
-    result.json({
+    response.json({
       data: entry,
       error: null,
     });
   } catch (error) {
-    result.status(404).json({
+    response.status(404).json({
       data: {},
       error: error.message,
     });
   }
 }
-export async function editEntry(request, result) {
+export async function editEntry(request, response) {
   try {
     const { title, body } = request.body;
     const diary = await Diary.findByIdAndUpdate(request.params.id, { title, body });
-    result.json({
+    response.json({
       data: diary,
       error: null,
     });
   } catch (error) {
-    result.status(400).json({
+    response.status(400).json({
       data: {},
       error: error.message,
     });
   }
 }
-export async function deleteEntry(request, result) {
+export async function deleteEntry(request, response) {
   try {
     const { id } = request.params;
     const diary = await Diary.findByIdAndDelete(id);
-    result.json({
+    response.json({
       data: diary,
       error: null,
     });
   } catch (error) {
-    result.status(400).json({
+    response.status(400).json({
       data: {},
       error: error.message,
     });

--- a/server/controllers/user.js
+++ b/server/controllers/user.js
@@ -13,7 +13,8 @@ export async function signup(request, response) {
     const user = await newUser.save();
     sendResponse({ response, data: user, status: 201 });
   } catch (error) {
-    sendResponse({ response, error: error.message, status: 400 });
+    if (error.message === 'duplicate key value violates unique constraint "authentication_username_key"') error.message = 'username has been chosen';
+    sendResponse({ response, error: [error.message], status: 400 });
   }
 }
 
@@ -27,6 +28,6 @@ export async function login(request, response) {
     const user = await returningUser.login();
     sendResponse({ response, data: user });
   } catch (error) {
-    sendResponse({ response, error: error.message, status: 401 });
+    sendResponse({ response, error: [error.message], status: 401 });
   }
 }

--- a/server/helpers/utils.js
+++ b/server/helpers/utils.js
@@ -1,3 +1,22 @@
+import jwt from 'jsonwebtoken';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const authenticate = async (request, response, next) => {
+  try {
+    const token = request.headers['x-auth-token'];
+    if (!token) throw new Error('token is required');
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    request.user = decoded.data;
+    next();
+  } catch (error) {
+    response.status(401).json({
+      data: {},
+      error: [error.message],
+    });
+  }
+};
 const validator = (rules) => {
   return (request, response, next) => {
     const error = Object.keys(rules).map((field) => {
@@ -33,6 +52,7 @@ const sendResponse = ({
 };
 
 export {
+  authenticate,
   validator,
   required,
   minLength,

--- a/server/migrations/dbSetupQuery.js
+++ b/server/migrations/dbSetupQuery.js
@@ -11,20 +11,20 @@ CREATE TABLE IF NOT EXISTS users(
 const authentication = `
 CREATE TABLE IF NOT EXISTS authentication(
   id SERIAL PRIMARY KEY,
-  username VARCHAR(50) NOT NULL,
+  username VARCHAR(150) UNIQUE NOT NULL,
   password TEXT NOT NULL
 );`;
 
 const entries = `
 CREATE TABLE IF NOT EXISTS entries(
   id SERIAL PRIMARY KEY,
-  "userId" INT,
+  "authorId" INT,
   title TEXT NOT NULL,
   body TEXT NOT NULL,
   created timestamp (0) without time zone default now(),
   edited timestamp (0) without time zone default now(),
-  CONSTRAINT FK_Entries_Users FOREIGN KEY ("userId") REFERENCES users(id)
-  
+  CONSTRAINT FK_Entries_Users FOREIGN KEY ("authorId") REFERENCES users(id)
+  ON DELETE CASCADE  
 );`;
 
 const notificationStatus = `
@@ -32,8 +32,16 @@ CREATE TABLE IF NOT EXISTS notificationStatus(
   id SERIAL PRIMARY KEY,
   "userId" INT,
   value BOOLEAN DEFAULT false,
-  CONSTRAINT FK_NotificationStatus_Users FOREIGN KEY ("userId") REFERENCES authentication(id)
+  CONSTRAINT FK_NotificationStatus_Users FOREIGN KEY ("userId") REFERENCES users(id)
+  ON DELETE CASCADE
   
 );`;
 
+const dropTables = `
+DROP TABLE IF EXISTS authentication cascade;
+DROP TABLE IF EXISTS users cascade;
+DROP TABLE IF EXISTS entries cascade;
+DROP TABLE IF EXISTS notificationStatus cascade;
+`;
 export default `${authentication}${users}${entries}${notificationStatus}`;
+export { dropTables };

--- a/server/migrations/dropTables.js
+++ b/server/migrations/dropTables.js
@@ -1,15 +1,9 @@
 import { Client } from 'pg';
 import winston from 'winston';
 import dotenv from 'dotenv';
+import { dropTables } from './dbSetupQuery';
 
 dotenv.config();
-
-const dropTables = `
-DROP TABLE IF EXISTS authentication cascade;
-DROP TABLE IF EXISTS users cascade;
-DROP TABLE IF EXISTS entries cascade;
-DROP TABLE IF EXISTS notificationStatus cascade;
-`;
 
 const client = new Client();
 client.query(dropTables, (error) => {

--- a/server/models/Diary.js
+++ b/server/models/Diary.js
@@ -1,4 +1,5 @@
 import { required, minLength, dataType } from '../helpers/utils';
+import client from '../helpers/connection';
 
 const diaries = [];
 
@@ -12,10 +13,6 @@ const postRules = {
     [required],
     [minLength, 15],
     [dataType, 'string'],
-  ],
-  author: [
-    [required],
-    [dataType, 'number'],
   ],
 };
 const putRules = {
@@ -32,27 +29,15 @@ const putRules = {
 };
 export default class Diary {
   constructor({ title, body, author }) {
-    const now = new Date().getTime();
-    const random = Math.floor(Math.random() * 1000);
     this.title = title;
     this.body = body;
     this.author = author;
-    this.id = Number(now.toString().concat(random));
   }
 
-  static save(diary) {
-    return new Promise((resolve, reject) => {
-      try {
-        if (diary instanceof this) {
-          diaries.push(diary);
-          resolve(diary);
-        } else {
-          throw new Error(`${diary} is not a diary`);
-        }
-      } catch (e) {
-        reject(new Error(e));
-      }
-    });
+  async save() {
+    const addDiaryQuery = 'INSERT INTO entries("title", body, "authorId") VALUES($1, $2, $3) RETURNING id, title, body, created, edited';
+    const addDiary = await client.query(addDiaryQuery, [this.title, this.body, this.author.id]);
+    return { ...addDiary.rows[0], author: this.author };
   }
 
   static findById(id) {

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -48,6 +48,11 @@ export default class User {
     this.password = password;
   }
 
+  static async remove(username) {
+    const removeUser = await client.query(`DELETE FROM authentication WHERE username='${username}' RETURNING id, username`);
+    return removeUser;
+  }
+
   async save() {
     this.password = await bcrypt.hash(this.password, 5);
     const authQuery = 'INSERT INTO authentication(username, password) VALUES($1, $2) RETURNING id';
@@ -60,25 +65,21 @@ export default class User {
   }
 
   async login() {
-    try {
-      const authQuery = `SELECT users.id, authentication.password, authentication.username, users."fullName", users.email FROM authentication INNER JOIN users 
-      ON users."authId" = authentication.id 
-      WHERE authentication.username = '${this.username}'`;
-      const getUser = await client.query(authQuery);
-      const user = getUser.rows[0];
-      if (!user) return new Error('user not found');
-      const correctPassword = await bcrypt.compare(this.password, getUser.rows[0].password);
-      if (correctPassword) {
-        this.fullName = user.fullName;
-        this.email = user.email;
-        this.id = user.id;
-        this.token = await this.genToken();
-        return Promise.resolve(this.strip());
-      }
-      throw new Error('user not found');
-    } catch (error) {
-      return Promise.reject(error);
+    const authQuery = `SELECT users.id, authentication.password, authentication.username, users."fullName", users.email FROM authentication INNER JOIN users 
+    ON users."authId" = authentication.id 
+    WHERE authentication.username = '${this.username}'`;
+    const getUser = await client.query(authQuery);
+    const user = getUser.rows[0];
+    if (!user) return new Error('user not found');
+    const isCorrectPassword = await bcrypt.compare(this.password, getUser.rows[0].password);
+    if (isCorrectPassword) {
+      this.fullName = user.fullName;
+      this.email = user.email;
+      this.id = user.id;
+      this.token = await this.genToken();
+      return this.strip();
     }
+    throw new Error('user not found');
   }
 
   async genToken() {

--- a/server/routes/entry.js
+++ b/server/routes/entry.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import { postRules, putRules } from '../models/Diary';
-import { validator } from '../helpers/utils';
+import { validator, authenticate } from '../helpers/utils';
 import {
   postEntry,
   getEntries,
@@ -10,7 +10,7 @@ import {
 } from '../controllers/entries';
 
 const router = express.Router();
-
+router.use(authenticate);
 router.post('/entries', validator(postRules), postEntry);
 router.get('/entries', getEntries);
 router.get('/entries/:id', getEntry);

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -8,6 +8,6 @@ const router = express.Router();
 router.get('/', (req, res) => {
   res.send('Server is live');
 });
-router.use(diary);
 router.use(user);
+router.use(diary);
 export default router;

--- a/server/tests/addEntry.spec.js
+++ b/server/tests/addEntry.spec.js
@@ -1,0 +1,79 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+
+import app from '../index';
+import User from '../models/User';
+
+chai.use(chaiHttp);
+
+const userDetails = {
+  username: 'johndoe',
+  fullName: 'John Doe',
+  password: 'mypassword',
+  email: 'johndoe@gmail.com',
+};
+const diaryTemplate = { title: 'My awesome diary', body: 'This is the body of my awesome diary' };
+const rootUrl = '/api/v1';
+
+export default function () {
+  describe('POST /entries', () => {
+    let user;
+    before('add user to db and log him in before test', async () => {
+      await chai.request(app).post(`${rootUrl}/auth/signup`).send(userDetails);
+      const login = await chai.request(app).post(`${rootUrl}/auth/login`)
+        .send({ username: userDetails.username, password: userDetails.password });
+      user = login.body.data;
+    });
+    after('delete user after test', async () => {
+      after('remove user after test', async () => {
+        const response = await User.remove(user.username);
+        expect(response.rowCount).to.equal(1);
+        expect(response.rows[0]).to.include({ username: user.username });
+      });
+    });
+    const route = '/entries';
+    it('should add entry to database', async () => {
+      const response = await chai.request(app).post(rootUrl + route)
+        .set('x-auth-token', user.token).send(diaryTemplate);
+      expect(response).to.have.status(201);
+      expect(response.body.data).to.include({
+        title: diaryTemplate.title,
+        body: diaryTemplate.body,
+      });
+      expect(response.body.data.author).to.include({
+        fullName: userDetails.fullName,
+        username: userDetails.username,
+        email: userDetails.email,
+      }).but.not.have.property('password');
+      expect(response.body.data).to.have.property('id');
+      expect(response.body.data).to.have.property('created');
+      expect(response.body.data).to.have.property('edited');
+    });
+    it('should not add entry with bad token', async () => {
+      const response = await chai.request(app).post(rootUrl + route)
+        .set('x-auth-token', 'thisisacompromisedtoken22i349fuq3j990fw').send(diaryTemplate);
+      expect(response).to.have.status(401);
+      expect(response.body.data).to.eql({});
+      expect(response.body.error).to.include.members(['jwt malformed']);
+    });
+    it('should not add entry without bad token', async () => {
+      const response = await chai.request(app).post(rootUrl + route).send(diaryTemplate);
+      expect(response).to.have.status(401);
+      expect(response.body.data).to.eql({});
+      expect(response.body.error).to.include.members(['token is required']);
+    });
+    it('should not add entries with bad details', async () => {
+      const badDetails = {
+        body: 'This entry has bad details because it has no title',
+      };
+      const response = await chai.request(app).post(rootUrl + route).set('x-auth-token', user.token).send(badDetails);
+
+      expect(response).to.have.status(400);
+      expect(response.body.error).to.include.members([
+        'title is required',
+        'title should have minimum of 5 characters',
+        'title should be of type string',
+      ]);
+    });
+  });
+}

--- a/server/tests/diary.spec.js
+++ b/server/tests/diary.spec.js
@@ -129,31 +129,6 @@ export default function () {
     });
   });
   describe('routes', () => {
-    describe('POST /entries', () => {
-      const route = '/entries';
-      it('should add entry to database', async () => {
-        const res = await chai.request(app).post(rootUrl + route).send(diaryTemplate);
-        const { id } = res.body.data;
-        expect(res).to.have.status(200);
-        expect(res.body.data).to.include({ title: diaryTemplate.title, body: diaryTemplate.body, author: diaryTemplate.author }).and.have.property('id');
-        // verify that id was successfully added, then delete
-        await Diary.findByIdAndDelete(id);
-      });
-      it('should not add entries with bad details', async () => {
-        const badDetails = {
-          body: 'This entry has bad details because it has no title',
-          author: 1,
-        };
-        const res = await chai.request(app).post(rootUrl + route).send(badDetails);
-
-        expect(res).to.have.status(400);
-        expect(res.body.error).to.include.members([
-          'title is required',
-          'title should have minimum of 5 characters',
-          'title should be of type string',
-        ]);
-      });
-    });
     describe('GET /entries', () => {
       const route = '/entries';
       it('should return all entries', async () => {

--- a/server/tests/index.spec.js
+++ b/server/tests/index.spec.js
@@ -1,14 +1,21 @@
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 
+import client from '../helpers/connection';
+import dbSetupQuery, { dropTables } from '../migrations/dbSetupQuery';
 import app from '../index';
 import diarySpec from './diary.spec';
 import signupSpec from './signup.spec';
 import loginSpec from './login.spec';
+import addEntrySpec from './addEntry.spec';
 
+process.env.NODE_ENV = 'test';
 chai.use(chaiHttp);
 const rootUrl = '/api/v1';
 
+(async () => {
+  await client.query(`${dropTables}${dbSetupQuery}`);
+})();
 describe('SERVER', () => {
   it('should be alive', async () => {
     const res = await chai.request(app).get(rootUrl);
@@ -17,6 +24,7 @@ describe('SERVER', () => {
     expect(res.type).to.equal('text/html');
   });
 });
-diarySpec();
+// diarySpec();
 signupSpec();
 loginSpec();
+addEntrySpec();

--- a/server/tests/signup.spec.js
+++ b/server/tests/signup.spec.js
@@ -2,6 +2,7 @@ import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 
 import app from '../index';
+import User from '../models/User';
 
 chai.use(chaiHttp);
 
@@ -14,33 +15,38 @@ const user = {
 const rootUrl = '/api/v1';
 
 export default function () {
-  describe('routes', () => {
-    describe('POST /auth/signup', () => {
-      const route = '/auth/signup';
-      it('should add user to database', async () => {
-        const res = await chai.request(app).post(rootUrl + route).send(user);
-        expect(res).to.have.status(201);
-        expect(res.body.data).to.include({ fullName: user.fullName, username: user.username }).and.have.property('id').but.not.have.property('password');
-      });
-      it('should not add user with bad details', async () => {
-        const badUser = {
-          fullName: 'Bad User',
-          username: 'johndoe',
-        };
-        const res = await chai.request(app).post(rootUrl + route).send(badUser);
-
-        expect(res).to.have.status(400);
-        expect(res.body.error).to.include.members([
-          'password is required',
-          'password should have minimum of 8 characters',
-          'password should be of type string',
-          'email is required',
-          'email should be of type email',
-        ]);
-      });
-      it('should not add existing user', async () => {
-
-      });
+  describe('POST /auth/signup', () => {
+    const route = '/auth/signup';
+    after('remove user after test', async () => {
+      const response = await User.remove(user.username);
+      expect(response.rowCount).to.equal(1);
+      expect(response.rows[0]).to.include({ username: user.username });
+    });
+    it('should add user to database', async () => {
+      const response = await chai.request(app).post(rootUrl + route).send(user);
+      expect(response).to.have.status(201);
+      expect(response.body.data).to.include({ fullName: user.fullName, username: user.username }).and.have.property('id').but.not.have.property('password');
+    });
+    it('should not add user with bad details', async () => {
+      const badUser = {
+        fullName: 'Bad User',
+        username: 'johndoe',
+      };
+      const response = await chai.request(app).post(rootUrl + route).send(badUser);
+      expect(response).to.have.status(400);
+      expect(response.body.error).to.include.members([
+        'password is required',
+        'password should have minimum of 8 characters',
+        'password should be of type string',
+        'email is required',
+        'email should be of type email',
+      ]);
+    });
+    it('should not add existing user', async () => {
+      const response = await chai.request(app).post(rootUrl + route).send(user);
+      expect(response).to.have.status(400);
+      expect(response.body.data).to.eql({});
+      expect(response.body.error).to.include.members(['username has been chosen']);
     });
   });
 }


### PR DESCRIPTION
#### What does this PR do?

- add authentication to /entries routes
- implement data persistence in POST /entries
- refactor POST /entries response for simplicity and readability
- modify addEntry.spec test to conform with POST /entries modifications
- addEntry.spec test passing

#### Description of Task to be completed?
none

#### How should this be manually tested?
`npm test`
Or by sending a POST resquest to /entries via post man or similar after the app has been started with `npm start`

#### Any background context you want to provide?
n/a

#### What are the relevant pivotal tracker stories?
[#159423801](https://www.pivotaltracker.com/n/projects/2183381/stories/159423801)
Screenshots (if appropriate)
n/a

Questions:
None