### PR TITLE
#159469058  implement entry update on endpoint PUT /entries/:id

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
       "import/prefer-default-export": 0,
       "arrow-body-style": 0,
       "no-confusing-arrow": 0,
-      "valid-typeof": 0
+      "valid-typeof": 0,
+      "prefer-destructuring": 1
   }
 }

--- a/server/controllers/entries.js
+++ b/server/controllers/entries.js
@@ -1,7 +1,7 @@
 import Diary from '../models/Diary';
 import { sendResponse } from '../helpers/utils';
 
-export async function postEntry(request, response) {
+const postEntry = async (request, response) => {
   try {
     const { title, body } = request.body;
     const author = request.user;
@@ -11,57 +11,47 @@ export async function postEntry(request, response) {
   } catch (error) {
     sendResponse({ response, error: [error.message], status: 400 });
   }
-}
-export async function getEntries(request, response) {
+};
+const getEntries = async (request, response) => {
   try {
     const entries = await Diary.find(request.user);
-    sendResponse({ response, data: entries, status: 200 });
+    sendResponse({ response, data: entries });
   } catch (error) {
     sendResponse({ response, error: [error.message], status: 400 });
   }
-}
-export async function getEntry(request, response) {
+};
+const getEntry = async (request, response) => {
   try {
     const { id } = request.params;
-    const entry = await Diary.findById(id);
-    response.json({
-      data: entry,
-      error: null,
-    });
+    const diary = await Diary.findById(id, request.user);
+    sendResponse({ response, data: diary });
   } catch (error) {
-    response.status(404).json({
-      data: {},
-      error: error.message,
-    });
+    sendResponse({ response, error: [error.message], status: 404 });
   }
-}
-export async function editEntry(request, response) {
+};
+const editEntry = async (request, response) => {
   try {
     const { title, body } = request.body;
-    const diary = await Diary.findByIdAndUpdate(request.params.id, { title, body });
-    response.json({
-      data: diary,
-      error: null,
-    });
+    const diary = await Diary.findByIdAndUpdate(request.params.id, request.user, { title, body });
+    sendResponse({ response, data: diary });
   } catch (error) {
-    response.status(400).json({
-      data: {},
-      error: error.message,
-    });
+    sendResponse({ response, error: [error.message], status: error.message === 'entry not found' ? 404 : 400 });
   }
-}
-export async function deleteEntry(request, response) {
+};
+const deleteEntry = async (request, response) => {
   try {
     const { id } = request.params;
     const diary = await Diary.findByIdAndDelete(id);
-    response.json({
-      data: diary,
-      error: null,
-    });
+    sendResponse({ response, data: diary });
   } catch (error) {
-    response.status(400).json({
-      data: {},
-      error: error.message,
-    });
+    sendResponse({ response, error: [error.message], status: 404 });
   }
-}
+};
+
+export {
+  postEntry,
+  getEntries,
+  getEntry,
+  editEntry,
+  deleteEntry,
+};

--- a/server/helpers/utils.js
+++ b/server/helpers/utils.js
@@ -19,9 +19,13 @@ const authenticate = async (request, response, next) => {
 };
 const validator = (rules) => {
   return (request, response, next) => {
+    request.body = Object.keys(request.body).reduce((accumulator, current) => {
+      accumulator[current] = typeof request.body[current] === 'string' ? request.body[current].trim() : request.body[current];
+      return accumulator;
+    }, {});
     const error = Object.keys(rules).map((field) => {
       return rules[field].map(rule => rule[0](
-        typeof request.body[field] === 'string' ? request.body[field].trim() : request.body[field],
+        request.body[field],
         field,
         rule[1],
       ));

--- a/server/tests/addEntry.spec.js
+++ b/server/tests/addEntry.spec.js
@@ -62,7 +62,7 @@ export default function () {
       expect(response.body.data).to.eql({});
       expect(response.body.error).to.include.members(['token is required']);
     });
-    it('should not add entries with bad details', async () => {
+    it('should not add entries if data excludes required field(s)', async () => {
       const badDetails = {
         body: 'This entry has bad details because it has no title',
       };

--- a/server/tests/getEntry.spec.js
+++ b/server/tests/getEntry.spec.js
@@ -16,44 +16,52 @@ const diaryTemplate = { title: 'My second awesome diary', body: 'This is the bod
 const rootUrl = '/api/v1';
 
 export default function () {
-  const route = '/entries';
-  describe('GET /entries', () => {
+  describe('GET /entries/:id', () => {
     let user;
+    let id;
     before('add user, log him in and add entry before test', async () => {
       await chai.request(app).post(`${rootUrl}/auth/signup`).send(userDetails);
       const login = await chai.request(app).post(`${rootUrl}/auth/login`)
         .send({ username: userDetails.username, password: userDetails.password });
       user = login.body.data;
-      await chai.request(app).post(`${rootUrl}/entries`)
+      const entry = await chai.request(app).post(`${rootUrl}/entries`)
         .set('x-auth-token', user.token).send(diaryTemplate);
+      id = entry.body.data.id;
     });
     after('delete user after test', async () => {
       after('remove user after test', async () => {
         await User.remove(user.username);
       });
     });
-    it('should return all entries', async () => {
-      const response = await chai.request(app).get(rootUrl + route)
+    it('should return specified entry', async () => {
+      const response = await chai.request(app).get(`${rootUrl}/entries/${id}`)
         .set('x-auth-token', user.token);
       expect(response).to.have.status(200);
-      expect(response.body.data).to.be.an('array');
-      expect(response.body.data.length).to.be.greaterThan(0);
-      expect(response.body.data[0]).to.have.property('id');
-      expect(response.body.data[0]).to.have.property('title');
-      expect(response.body.data[0]).to.have.property('body');
-      expect(response.body.data[0]).to.have.property('authorId');
-      expect(response.body.data[0]).to.have.property('created');
-      expect(response.body.data[0]).to.have.property('edited');
+      expect(response.body.data).to.be.an('object');
+      expect(response.body.data).to.include({
+        title: diaryTemplate.title,
+        body: diaryTemplate.body,
+      });
+      expect(response.body.data).to.have.property('authorId');
+      expect(response.body.data).to.have.property('created');
+      expect(response.body.data).to.have.property('edited');
+    });
+    it('should return error if id is not found', async () => {
+      const response = await chai.request(app).get(`${rootUrl}/entries/${7.3}`)
+        .set('x-auth-token', user.token);
+      expect(response).to.have.status(404);
+      expect(response.body.data).to.eql({});
+      expect(response.body.error).to.include.members(['entry not found']);
     });
     it('should return error when token is compromised', async () => {
-      const response = await chai.request(app).post(rootUrl + route)
-        .set('x-auth-token', 'thisisacompromisedtoken22i349fuq3j990fw').send(diaryTemplate);
+      const response = await chai.request(app).get(`${rootUrl}/entries/${id}`)
+        .set('x-auth-token', 'thisisacompromisedtoken22i349fuq3j990fw');
       expect(response).to.have.status(401);
       expect(response.body.data).to.eql({});
       expect(response.body.error).to.include.members(['jwt malformed']);
     });
     it('should return error when token is not given', async () => {
-      const response = await chai.request(app).post(rootUrl + route).send(diaryTemplate);
+      const response = await chai.request(app).get(`${rootUrl}/entries/${id}`);
       expect(response).to.have.status(401);
       expect(response.body.data).to.eql({});
       expect(response.body.error).to.include.members(['token is required']);

--- a/server/tests/index.spec.js
+++ b/server/tests/index.spec.js
@@ -9,6 +9,8 @@ import signupSpec from './signup.spec';
 import loginSpec from './login.spec';
 import addEntrySpec from './addEntry.spec';
 import getEntriesSpec from './getEntries.spec';
+import getEntrySpec from './getEntry.spec';
+import modifyEntrySpec from './modifyEntry.spec';
 
 process.env.NODE_ENV = 'test';
 chai.use(chaiHttp);
@@ -30,3 +32,5 @@ signupSpec();
 loginSpec();
 addEntrySpec();
 getEntriesSpec();
+getEntrySpec();
+modifyEntrySpec();

--- a/server/tests/modifyEntry.spec.js
+++ b/server/tests/modifyEntry.spec.js
@@ -1,0 +1,89 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+
+import app from '../index';
+import User from '../models/User';
+
+chai.use(chaiHttp);
+
+const userDetails = {
+  username: 'johndoe',
+  fullName: 'John Doe',
+  password: 'mypassword',
+  email: 'johndoe@gmail.com',
+};
+const diaryTemplate = { title: 'My third awesome diary', body: 'This is the body of my third awesome diary' };
+const rootUrl = '/api/v1';
+
+export default function () {
+  describe('PUT /entries/:id', () => {
+    const modification = {
+      title: 'My very awesome title',
+      body: 'As you can see, I have modified the body now since the title is more awesome :)',
+    };
+    let user;
+    let id;
+    before('add user, log him in and add entry before test', async () => {
+      await chai.request(app).post(`${rootUrl}/auth/signup`).send(userDetails);
+      const login = await chai.request(app).post(`${rootUrl}/auth/login`)
+        .send({ username: userDetails.username, password: userDetails.password });
+      user = login.body.data;
+      const entry = await chai.request(app).post(`${rootUrl}/entries`)
+        .set('x-auth-token', user.token).send(diaryTemplate);
+      id = entry.body.data.id;
+    });
+    after('delete user after test', async () => {
+      after('remove user after test', async () => {
+        await User.remove(user.username);
+      });
+    });
+    it('should modify specified entry and return new value', async () => {
+      const response = await chai.request(app).put(`${rootUrl}/entries/${id}`)
+        .set('x-auth-token', user.token).send(modification);
+      expect(response).to.have.status(200);
+      expect(response.body.data).to.be.an('object');
+      expect(response.body.data).to.include({
+        title: modification.title,
+        body: modification.body,
+      });
+      expect(response.body.data).to.have.property('authorId');
+      expect(response.body.data).to.have.property('created');
+      expect(response.body.data).to.have.property('edited');
+    });
+    it('should return error if modification excludes required field(s)', async () => {
+      const badData = {
+        body: 'I am a bad data, I will cause an error because I dont have a title',
+      };
+      const response = await chai.request(app).put(`${rootUrl}/entries/${id}`)
+        .set('x-auth-token', user.token).send(badData);
+      expect(response).to.have.status(400);
+      expect(response.body.data).to.eql({});
+      expect(response.body.error).to.include.members([
+        'title is required',
+        'title should have minimum of 5 characters',
+        'title should be of type string',
+      ]);
+    });
+    it('should return error if specified id is not found', async () => {
+      const response = await chai.request(app).put(`${rootUrl}/entries/${7.3}`)
+        .set('x-auth-token', user.token).send(modification);
+      expect(response).to.have.status(404);
+      expect(response.body.data).to.eql({});
+      expect(response.body.error).to.include.members(['entry not found']);
+    });
+    it('should return error if token is compromised', async () => {
+      const response = await chai.request(app).put(`${rootUrl}/entries/${id}`)
+        .set('x-auth-token', 'thisisacompromisedtoken22i349fuq3j990fw').send(modification);
+
+      expect(response).to.have.status(401);
+      expect(response.body.data).to.eql({});
+      expect(response.body.error).to.include.members(['jwt malformed']);
+    });
+    it('should return error if token is not given', async () => {
+      const response = await chai.request(app).put(`${rootUrl}/entries/${id}`).send(modification);
+      expect(response).to.have.status(401);
+      expect(response.body.data).to.eql({});
+      expect(response.body.error).to.include.members(['token is required']);
+    });
+  });
+}

--- a/server/tests/signup.spec.js
+++ b/server/tests/signup.spec.js
@@ -10,7 +10,7 @@ const user = {
   username: 'johndoe',
   fullName: 'John Doe',
   password: 'mypassword',
-  email: 'johndoe@gmail.com',
+  email: '    johndoe@gmail.com',
 };
 const rootUrl = '/api/v1';
 
@@ -25,9 +25,9 @@ export default function () {
     it('should add user to database', async () => {
       const response = await chai.request(app).post(rootUrl + route).send(user);
       expect(response).to.have.status(201);
-      expect(response.body.data).to.include({ fullName: user.fullName, username: user.username }).and.have.property('id').but.not.have.property('password');
+      expect(response.body.data).to.include({ fullName: user.fullName, username: user.username, email: user.email.trim() }).and.have.property('id').but.not.have.property('password');
     });
-    it('should not add user with bad details', async () => {
+    it('should not add user if data excludes required field(s)', async () => {
       const badUser = {
         fullName: 'Bad User',
         username: 'johndoe',


### PR DESCRIPTION
#### What does this PR do?

- update static findById method in Diary model
- add modifyDiary spec to validate date entry is modified and returned when id is valid
- add modifyDiary spec to validate date error is returned when id is invalid
- add modifyDiary spec to validate date error is returned when invalid modification data is passed
- add modifyDiary spec to validate date error is returned when token is invalid or not given
- all modifyDiary spec passing
- update validator in utils to trim all fields in request.body

#### Description of Task to be completed?
none

#### How should this be manually tested?
`npm test`
Or by sending a PUT resquest to /entries/:id passing a valid `id` and valid modification data via post man or similar after the app has been started with `npm start`

#### Any background context you want to provide?
n/a

#### What are the relevant pivotal tracker stories?
[#159469058](https://www.pivotaltracker.com/n/projects/2183381/stories/159469058)
Screenshots (if appropriate)
n/a

Questions:
None